### PR TITLE
Fixed ternary syntax to work with php 5.2 that is required by magento.

### DIFF
--- a/code/Model/Session.php
+++ b/code/Model/Session.php
@@ -55,12 +55,13 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
 
     public function __construct()
     {
-        $host = (string)   (Mage::getConfig()->getNode(self::XML_PATH_HOST) ?: '127.0.0.1');
-        $port = (int)      (Mage::getConfig()->getNode(self::XML_PATH_PORT) ?: '6379');
-        $timeout = (float) (Mage::getConfig()->getNode(self::XML_PATH_TIMEOUT) ?: '2.5');
-        $this->_dbNum = (int) (Mage::getConfig()->getNode(self::XML_PATH_DB) ?: 0);
-        $this->_compressionThreshold = (int) (Mage::getConfig()->getNode(self::XML_PATH_COMPRESSION_THRESHOLD) ?: 2048);
-        $this->_compressionLib = (string) (Mage::getConfig()->getNode(self::XML_PATH_COMPRESSION_LIB) ?: 'gzip');
+        $host = (string) (Mage::getConfig()->getNode(self::XML_PATH_HOST) ? Mage::getConfig()->getNode(self::XML_PATH_HOST) : '127.0.0.1');
+        $port = (int) (Mage::getConfig()->getNode(self::XML_PATH_PORT) ? Mage::getConfig()->getNode(self::XML_PATH_PORT) : '6379');
+        $timeout = (float) (Mage::getConfig()->getNode(self::XML_PATH_TIMEOUT) ? Mage::getConfig()->getNode(self::XML_PATH_TIMEOUT) : '2.5');
+        $this->_dbNum = (int) (Mage::getConfig()->getNode(self::XML_PATH_DB) ? Mage::getConfig()->getNode(self::XML_PATH_DB) : 0);
+        $this->_compressionThreshold = (int) (Mage::getConfig()->getNode(self::XML_PATH_COMPRESSION_THRESHOLD) ? Mage::getConfig()->getNode(self::XML_PATH_COMPRESSION_THRESHOLD) : 2048);
+        $this->_compressionLib = (string) (Mage::getConfig()->getNode(self::XML_PATH_COMPRESSION_LIB) ? Mage::getConfig()->getNode(self::XML_PATH_COMPRESSION_LIB) : 'gzip');
+
         $this->_redis = new Credis_Client($host, $port, $timeout);
         $this->_useRedis = TRUE;
     }


### PR DESCRIPTION
Hello Collin, 
i encounterd the problem that the ternary statements  between ll. 58 and 63 did not work in php 5.2.x because you used 5.3 syntax for that by ommiting expr2. 
Maybe it could be updated with this short fix to work in an environment that normally is fully working with magento with php 5.2.x versions. 
Hopefully done this right because this is my first pull request i ever write :)
