### PR TITLE
Fix modman

### DIFF
--- a/modman
+++ b/modman
@@ -1,4 +1,4 @@
 # Cm_RedisSession
 code                                   app/code/community/Cm/RedisSession
 Cm_RedisSession.xml                    app/etc/modules/Cm_RedisSession.xml
-lib/Credis                             lib/Credis
+lib/*                             lib/


### PR DESCRIPTION
Prevent linking empty folder when Credis is already
linked (e.g. from Cm_Cache_Backend_Redis module)

After last change in modman file - linking Credis submodule, I've got some errors because I already had Credis module linked from Cache backend module and I havent checked it out again for Sessions module.
This patch makes it safe to checkout Credis only in one redis module (cache or sessions)
