### PR TITLE
Set min/max default session lifetime via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Be aware that if the `<max_lifetime>` setting is below your Cookie Lifetime, the
             <bot_first_lifetime>60</bot_first_lifetime>          <!-- Lifetime of session for bots on the first write. 0 to disable -->
             <bot_lifetime>7200</bot_lifetime>                    <!-- Lifetime of session for bots on subsequent writes. 0 to disable -->
             <disable_locking>0</disable_locking>                 <!-- Disable session locking entirely. -->
-            <min_lifetime>2592000</min_lifetime>                <!-- Set the minimum session lifetime -->
-            <max_lifetime>60</max_lifetime>                     <!-- Set the maximum session lifetime -->
+            <min_lifetime>60</min_lifetime>                      <!-- Set the minimum session lifetime -->
+            <max_lifetime>2592000</max_lifetime>                 <!-- Set the maximum session lifetime -->
         </redis_session>
         ...
     </global>

--- a/code/Model/Session.php
+++ b/code/Model/Session.php
@@ -93,7 +93,7 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
     protected $_sessionWritten; // avoid infinite loops
     protected $_sessionWrites; // set expire time based on activity
     protected $_maxLifetime;
-	protected $_minLifetime;
+    protected $_minLifetime;
 
     static public $failedLockAttempts = 0; // for debug or informational purposes
 


### PR DESCRIPTION
Added the settings `<max_lifetime>` and `<min_lifetime>` to the config as we're running a shop where we're going beyond the default max lifetime of 30 days (`const MAX_LIFETIME = 2592000; /* Redis backend limit */`). Would make sense to override via config.
