### PR TITLE
Update migrateSessions_mysql_redis.php

### DIFF
--- a/migrateSessions_mysql_redis.php
+++ b/migrateSessions_mysql_redis.php
@@ -38,7 +38,7 @@ do {
     $query = $readConnection->select()
                         ->from(array('cs'=>$resource->getTableName('core/session')),
                                array('session_id', 'session_expires', 'session_data'))
-                        ->having("session_expires >= ?", $exptime)
+                        ->having("session_expires > ?", $exptime)
                         ->having("session_id != ?", $lastid)
                         ->limit($batchlimit)
                         ->order('session_expires');


### PR DESCRIPTION
It seems that the foreach never ended because of the >= operator in the query. This only happen when you have at least two session with the same expires date.