### PR TITLE
Minor fix for deploying in an already copied/existing directory

### DIFF
--- a/code/Model/Session.php
+++ b/code/Model/Session.php
@@ -384,7 +384,7 @@ class Cm_RedisSession_Model_Session extends Mage_Core_Model_Mysql4_Session
         // Reset flag in case of multiple session read/write operations
         $this->_sessionWritten = FALSE;
 
-        return $sessionData ? $this->_decodeData($sessionData) : '';
+        return $sessionData ? (string)$this->_decodeData($sessionData) : '';
     }
 
     /**


### PR DESCRIPTION
Putting the trail on the end it enforces to install it to a proper directory instead of appending code to the RedisSession dir. (fixed it for me)
Especially for composer installs
