### PR TITLE
removed call to parent class 

### DIFF
--- a/code/Model/Session.php
+++ b/code/Model/Session.php
@@ -551,7 +551,7 @@ class Cm_RedisSession_Model_Session implements Zend_Session_SaveHandler_Interfac
                     ) {
                         $lifeTime = $botFirstLifetime * (1+$this->_sessionWrites);
                     } else {
-                        $lifeTime = min(parent::getLifeTime(), $botLifetime);
+                        $lifeTime = $botLifetime;
                     }
                 }
             }


### PR DESCRIPTION
The call had to be removed because after d86c519 there is no parent class any more.