### PR TITLE
Fix install on older Magento versions.

### DIFF
--- a/Cm_RedisSession.xml
+++ b/Cm_RedisSession.xml
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <modules>
     <Cm_RedisSession>
       <active>true</active>
-      <codePool>community</codePool>
+      <codePool>local</codePool>
     </Cm_RedisSession>
   </modules>
 </config>


### PR DESCRIPTION
Refs #108. Match the codePool in module XML to location of code in modman file which was updated to avoid conflict with core files from bundled version.