### PR TITLE
GitHub 129 replace submodules with composer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "credis"]
-    path = credis
-    url = https://github.com/colinmollenhour/credis
-[submodule "php-redis-session-abstract"]
-	path = code/lib
-    url = https://github.com/colinmollenhour/php-redis-session-abstract

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "credis"]
+	path = credis
+	url = https://github.com/colinmollenhour/credis
+[submodule "code/lib"]
+	path = code/lib
+	url = https://github.com/colinmollenhour/php-redis-session-abstract

--- a/README.md
+++ b/README.md
@@ -32,11 +32,16 @@ Be aware that if the `<max_lifetime>` setting is below your Cookie Lifetime, the
 
 ## Installation ##
 
-1. Install module using [composer](https://getcomposer.org/) with the
+1a. Install module using [modman](https://github.com/colinmollenhour/modman):
+
+    modman clone https://github.com/colinmollenhour/Cm_RedisSession
+
+1b. Or install module using [composer](https://getcomposer.org/) with the
    [magento-composer-installer](https://github.com/Cotya/magento-composer-installer) plugin:
 
         composer require magento-hackathon/magento-composer-installer; # If not already installed
         composer require colinmollenhour/magento-redis-session;
+
 2. Remove lib/Credis from your Magento installation. This module includes a newer version of the
    Credis library and, due to the Magento 1 autoloader works, the version that ships with core
    Magento must be removed.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,14 @@ Be aware that if the `<max_lifetime>` setting is below your Cookie Lifetime, the
 
 ## Installation ##
 
-1. Install module using [modman](https://github.com/colinmollenhour/modman):
+1. Install module using [composer](https://getcomposer.org/) with the
+   [magento-composer-installer](https://github.com/Cotya/magento-composer-installer) plugin:
 
-        modman clone https://github.com/colinmollenhour/Cm_RedisSession
-
+        composer require magento-hackathon/magento-composer-installer; # If not already installed
+        composer require colinmollenhour/magento-redis-session;
+2. Remove lib/Credis from your Magento installation. This module includes a newer version of the
+   Credis library and, due to the Magento 1 autoloader works, the version that ships with core
+   Magento must be removed.
 2. Configure via app/etc/local.xml adding a `global/redis_session` section with the appropriate configuration if needed.
    See the "Configuration Example" below.
 3. Refresh the config cache to allow the module to be installed by Magento.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-      "colinmollenhour/php-redis-session-abstract": "~1.3.5"
+      "colinmollenhour/php-redis-session-abstract": "~1.3.5",
+      "colinmollenhour/credis": "^1.9.1"
     },
     "suggest":{
         "magento-hackathon/magento-composer-installer":"Makes it possible to manage this package as a dependency"

--- a/modman
+++ b/modman
@@ -1,4 +1,3 @@
 # Cm_RedisSession
 code                                            app/code/local/Cm/RedisSession
 Cm_RedisSession.xml                             app/etc/modules/Cm_RedisSession_Local.xml
-credis                                          app/code/local/Credis


### PR DESCRIPTION
There is no clean way to handle this... The magento-composer-installer plugin loads the Composer autoloader after the Magento autoloader so "lib/Credis" will always win over "vendor/colinmollenhour/credis". I think the cleanest solution is to suggest removing "lib/Credis" from core code. I added this to the README.

Ideally, I think the magento-composer-installer should load the Composer autoloader before the M1 autoloader, but that seems very unlikely to change since it's so widely used now and M1 is on its way to being replaced by M2.

This would be a breaking change for modman installations and would probably have to go into a 2.0.0
