### PR TITLE
migrate newest sessions first

### DIFF
--- a/migrateSessions_mysql_redis.php
+++ b/migrateSessions_mysql_redis.php
@@ -42,7 +42,7 @@ do {
                         ->having("session_expires > ?", $exptime)
                         ->having("session_id != ?", $lastid)
                         ->limit($batchlimit)
-                        ->order('session_expires');
+                        ->order('session_expires ' . Varien_Data_Collection::SORT_ORDER_DESC);
     $results = $readConnection->fetchAll($query);
     //var_dump($results);
     foreach($results as $row) {


### PR DESCRIPTION
IMHO, it makes more sense to migrate the newest sessions first. When doing so, one can cancel the migration script if it takes too long at some time without loosing the latest sessions.