### PR TITLE
Refactoring to let work again with php 7.4

### DIFF
--- a/app/code/community/Cm/RedisSession/Model/Session.php
+++ b/app/code/community/Cm/RedisSession/Model/Session.php
@@ -43,7 +43,11 @@ class Cm_RedisSession_Model_Session implements \Zend_Session_SaveHandler_Interfa
      * @var \Cm\RedisSession\Handler
      */
     protected $sessionHandler;
-    protected bool $dieOnError = true;
+
+    /**
+     * @var bool
+     */
+    protected $dieOnError = true;
 
     public function __construct($config = array())
     {
@@ -56,7 +60,12 @@ class Cm_RedisSession_Model_Session implements \Zend_Session_SaveHandler_Interfa
         );
     }
 
-    public function setDieOnError(bool $flag): void
+    /**
+     * Setup die on error
+     * 
+     * @param bool $flag
+     */
+    public function setDieOnError($flag)
     {
         $this->dieOnError = $flag;
     }


### PR DESCRIPTION
i know 7.4 is not supported anymore but i hope you let me do this. the latest version of openmage v19.5.0-rc3 is not working on 7.4 without this refactoring.