### PR TITLE
Make Session.php PHP 8.4 compatible

### DIFF
--- a/app/code/community/Cm/RedisSession/Model/Session.php
+++ b/app/code/community/Cm/RedisSession/Model/Session.php
@@ -68,14 +68,7 @@ class Cm_RedisSession_Model_Session implements SessionHandlerInterface
      */
     public function setSaveHandler()
     {
-        session_set_save_handler(
-            array($this, 'open'),
-            array($this, 'close'),
-            array($this, 'read'),
-            array($this, 'write'),
-            array($this, 'destroy'),
-            array($this, 'gc')
-        );
+        session_set_save_handler($this);
         return $this;
     }
 


### PR DESCRIPTION
Fixing deprecation warning in php 8.4:

Deprecated functionality: session_set_save_handler(): Providing individual callbacks instead of an object implementing SessionHandlerInterface is deprecated 

See also https://php.watch/versions/8.4/session_set_save_handler-alt-signature-deprecated#replacement